### PR TITLE
Refresh gatt cache

### DIFF
--- a/src/android/bluetooth/src/org/qtproject/qt5/android/bluetooth/QtBluetoothLE.java
+++ b/src/android/bluetooth/src/org/qtproject/qt5/android/bluetooth/QtBluetoothLE.java
@@ -559,11 +559,29 @@ public class QtBluetoothLE {
         return mBluetoothGatt != null;
     }
 
-    public void disconnect() {
+    public void disconnect(boolean refreshCache) {
         if (mBluetoothGatt == null)
             return;
 
         mBluetoothGatt.disconnect();
+
+	if(refreshCache == false)
+            return;
+
+	try
+	{
+	    Method refreshMethod = mBluetoothGatt.getClass().getMethod("refresh",null);
+	    if(refreshMethod != null)
+	    {
+	         boolean refreshedCache = ((Boolean) refreshMethod.invoke(mBluetoothGatt, null)).booleanValue();
+
+		 logMsg("BT Gatt cache refreshed successful: %b", refreshedCache);
+	    }
+	}
+	catch(Exception ex)
+	{
+	    logMsg("Exception refreshing BT Gatt cache: %s", ex.toString());	
+	}     
     }
 
     public boolean discoverServices()

--- a/src/bluetooth/qlowenergycontroller.cpp
+++ b/src/bluetooth/qlowenergycontroller.cpp
@@ -604,7 +604,7 @@ void QLowEnergyController::connectToDevice()
 
     \sa connectToDevice()
  */
-void QLowEnergyController::disconnectFromDevice()
+void QLowEnergyController::disconnectFromDevice(bool refreshGattCache)
 {
     Q_D(QLowEnergyController);
 
@@ -612,7 +612,7 @@ void QLowEnergyController::disconnectFromDevice()
         return;
 
     d->invalidateServices();
-    d->disconnectFromDevice();
+    d->disconnectFromDevice(refreshGattCache);
 }
 
 /*!

--- a/src/bluetooth/qlowenergycontroller.h
+++ b/src/bluetooth/qlowenergycontroller.h
@@ -118,7 +118,7 @@ public:
     void setRemoteAddressType(RemoteAddressType type);
 
     void connectToDevice();
-    void disconnectFromDevice();
+    void disconnectFromDevice(bool refreshGattCache = false);
 
     void discoverServices();
     QList<QBluetoothUuid> services() const;

--- a/src/bluetooth/qlowenergycontroller_android.cpp
+++ b/src/bluetooth/qlowenergycontroller_android.cpp
@@ -168,7 +168,7 @@ void QLowEnergyControllerPrivateAndroid::connectToDevice()
     }
 }
 
-void QLowEnergyControllerPrivateAndroid::disconnectFromDevice()
+void QLowEnergyControllerPrivateAndroid::disconnectFromDevice(bool refreshGattCache)
 {
     /* Catch an Android timeout bug. If the device is connecting but cannot
      * physically connect it seems to ignore the disconnect call below.
@@ -179,8 +179,13 @@ void QLowEnergyControllerPrivateAndroid::disconnectFromDevice()
     QLowEnergyController::ControllerState oldState = state;
     setState(QLowEnergyController::ClosingState);
 
+    if(refreshGattCache)
+	jboolean refresh = true;
+    else
+        jboolean refresh = false;
+
     if (hub)
-        hub->javaObject().callMethod<void>("disconnect");
+        hub->javaObject().callObjectMethod("disconnect","(Z)V",refresh);
 
     if (oldState == QLowEnergyController::ConnectingState)
         setState(QLowEnergyController::UnconnectedState);

--- a/src/bluetooth/qlowenergycontroller_android_p.h
+++ b/src/bluetooth/qlowenergycontroller_android_p.h
@@ -102,7 +102,7 @@ public:
     void init() override;
 
     void connectToDevice() override;
-    void disconnectFromDevice() override;
+    void disconnectFromDevice(bool refreshGattCache) override;
 
     void discoverServices() override;
     void discoverServiceDetails(const QBluetoothUuid &service) override;

--- a/src/bluetooth/qlowenergycontrollerbase_p.h
+++ b/src/bluetooth/qlowenergycontrollerbase_p.h
@@ -95,7 +95,7 @@ public:
     // interface definition
     virtual void init() = 0;
     virtual void connectToDevice() = 0;
-    virtual void disconnectFromDevice() = 0;
+    virtual void disconnectFromDevice(bool refreshGattCache) = 0;
 
     virtual void discoverServices() = 0;
     virtual void discoverServiceDetails(const QBluetoothUuid &/*service*/) = 0;


### PR DESCRIPTION
Hello,

I am developing a small chat application for Android devices using Bluetooth communication channel. As I wanted to program it in C++ I have chosen Qt as development platform. My goal was to allow the user to search for nearby devices. The list of nearby devices should only include devices having the app listening for incoming connections. In other words devices for which the app is not opened should not appear in the list. As I did not want the app to first pair with the remote device to then check if the app provides that service, I have decided to use the BLE controller implemented by Qt that presents the published services by a peripheral controller to any central device that would be searching around. Unfortunately I have realised that when the peripheral controller is off (i.e. the app is turned off) the service still appears in the discovered services by the central controller. As explained in Qt documentation some platform like Android caches the discovered services so subsequent discoveries will not update the initial found list of services. Since it represents an issue for the app I am trying to build up I am looking for a turnaround. As you probably know it is possible to clear the cache using a private method called "refresh" and accessible by reflection. I have looked up and it seems refreshing the cash after disconnecting gives good results (I was using the app nRF Connect to debug my app and it seems they use that approach). I therefore made some commits to add this functionality. By default the cache is not cleared but if the user wishes to clear it an boolean argument can be passed. I have updated the C++ files and java file. Unfortunately the public function "disconnectFromDevice"needs to be modified adding one boolean parameter. The lowenergycontrollerbase abstract class needs therefore to be modified. I have not modified the code for the other platforms.

Please let me know what you think about it. If in the (likely) case this request is rejected could you please let me know how you would tackle this issue? Have you received other requests of that type? By any chance do you know how they solve the problem?

Many thanks for your help,
Kind regards,
PeacocksFly
