### PR TITLE
Added <errno.h> include to make compilation with CLang successfully

### DIFF
--- a/src/bluetooth/bluez/bluetoothmanagement.cpp
+++ b/src/bluetooth/bluez/bluetoothmanagement.cpp
@@ -50,7 +50,7 @@
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <linux/capability.h>
-
+#include <errno.h>
 
 QT_BEGIN_NAMESPACE
 


### PR DESCRIPTION
Clang compiler seems not to autoadd some header files, in this case it fails because usage of errno is undefined.

Adding include for errno.h fixes the issue and makes compilation successful, also it might help for future gcc releases in case they decide to clean header includes.