### PR TITLE
pcsclite: fix configuration summary

### DIFF
--- a/src/nfc/configure.cmake
+++ b/src/nfc/configure.cmake
@@ -12,6 +12,6 @@ qt_feature("neard" PUBLIC
     CONDITION LINUX AND QT_FEATURE_dbus AND NOT QT_FEATURE_pcsclite)
 
 qt_configure_add_summary_section(NAME "Qt Nfc details")
-qt_configure_add_summary_entry(ARGS pcslite)
+qt_configure_add_summary_entry(ARGS pcsclite)
 qt_configure_add_summary_entry(ARGS neard)
 qt_configure_end_summary_section()


### PR DESCRIPTION
"Use the PCSCLite library to access NFC devices" is otherwise always shown as "no" due to a typo.